### PR TITLE
feat: add metadataBase in layout and add search in votaciones with ur…

### DIFF
--- a/app/components/VotacionFilter.tsx
+++ b/app/components/VotacionFilter.tsx
@@ -1,51 +1,77 @@
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Search } from "lucide-react";
 
 type VotacionFilterProps = {
-  selectedResult: string
-  selectedYear: string
-  onResultChange: (value: string) => void
-  onYearChange: (value: string) => void
-  possibleResults: string[]
-  possibleYears: string[]
-}
+  selectedResult: string;
+  selectedYear: string;
+  searchQuery: string;
+  onResultChange: (value: string) => void;
+  onYearChange: (value: string) => void;
+  onSearchChange: (value: string) => void;
+  possibleResults: string[];
+  possibleYears: string[];
+};
 
-export default function VotacionFilter({ 
-  selectedResult, 
+export default function VotacionFilter({
+  selectedResult,
   selectedYear,
-  onResultChange, 
+  searchQuery,
+  onResultChange,
   onYearChange,
+  onSearchChange,
   possibleResults,
-  possibleYears 
+  possibleYears
 }: VotacionFilterProps) {
   return (
-    <div className="mb-6 flex gap-4">
-      <Select value={selectedResult} onValueChange={onResultChange}>
-        <SelectTrigger className="w-[200px] bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
-          <SelectValue placeholder="Filtrar por resultado" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="TODOS">Todos los resultados</SelectItem>
-          {possibleResults.map((result) => (
-            <SelectItem key={result} value={result}>
-              {result.charAt(0).toUpperCase() + result.slice(1).toLowerCase()}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+    <div className="mb-6 space-y-4">
+      <div className="flex flex-col md:flex-row items-stretch md:items-center gap-4">
+        <div className="relative w-full">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 dark:text-gray-400 h-4 w-4" />
+          <Input
+            type="text"
+            placeholder="Buscar votaciones..."
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="pl-10 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 w-full"
+          />
+        </div>
+        <div className="flex flex-col sm:flex-row gap-4 md:w-96">
+          <Select value={selectedResult} onValueChange={onResultChange}>
+            <SelectTrigger className="w-full md:w-[220px] lg:w-96 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
+              <SelectValue placeholder="Filtrar por resultado" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="TODOS">Todos los resultados</SelectItem>
+              {possibleResults.map((result) => (
+                <SelectItem key={result} value={result}>
+                  {result.charAt(0).toUpperCase() + result.slice(1).toLowerCase()}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-      <Select value={selectedYear} onValueChange={onYearChange}>
-        <SelectTrigger className="w-[200px] bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
-          <SelectValue placeholder="Filtrar por año" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="TODOS">Todos los años</SelectItem>
-          {possibleYears.map((year) => (
-            <SelectItem key={year} value={year}>
-              {year}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+          <Select value={selectedYear} onValueChange={onYearChange}>
+            <SelectTrigger className="w-full md:w-[150px] lg:w-64 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
+              <SelectValue placeholder="Filtrar por año" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="TODOS">Todos los años</SelectItem>
+              {possibleYears.map((year) => (
+                <SelectItem key={year} value={year}>
+                  {year}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
     </div>
-  )
-} 
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,8 @@ export const metadata: Metadata = {
     },
     description: 'Portal de transparencia y análisis de votaciones del Senado de la Nación Argentina',
     images: ['/meta-image.png'],
-  }
+  },
+  metadataBase: new URL('https://senadores.argentinadatos.com'),
 }
 
 export default function RootLayout({

--- a/app/senadores/page.tsx
+++ b/app/senadores/page.tsx
@@ -1,28 +1,32 @@
-import type { Metadata } from "next"
-import SenadoresContent from "./SenadoresContent"
-import { Suspense } from "react"
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import SenadoresContent from "./SenadoresContent";
 
 export const metadata: Metadata = {
   title: "Senadores",
-  description: "Explora el listado completo de senadores, sus bloques políticos y su historial de votaciones en el Senado de la Nación Argentina.",
+  description:
+    "Explora el listado completo de senadores, sus bloques políticos y su historial de votaciones en el Senado de la Nación Argentina.",
   openGraph: {
     title: "Senadores | Senado Argentino",
-    description: "Explora el listado completo de senadores, sus bloques políticos y su historial de votaciones en el Senado de la Nación Argentina.",
-    images: [{
-      url: '/meta-image.png',
-      width: 1200,
-      height: 630,
-      alt: 'Senadores del Senado Argentino'
-    }]
+    description:
+      "Explora el listado completo de senadores, sus bloques políticos y su historial de votaciones en el Senado de la Nación Argentina.",
+    images: [
+      {
+        url: "/meta-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Senadores del Senado Argentino"
+      }
+    ]
   },
   twitter: {
-    card: 'summary_large_image',
+    card: "summary_large_image",
     title: "Senadores | Senado Argentino",
-    description: "Explora el listado completo de senadores, sus bloques políticos y su historial de votaciones en el Senado de la Nación Argentina.",
-    images: ['/meta-image.png']
-  },
-  metadataBase: new URL('https://senadores.argentinadatos.com'),
-}
+    description:
+      "Explora el listado completo de senadores, sus bloques políticos y su historial de votaciones en el Senado de la Nación Argentina.",
+    images: ["/meta-image.png"]
+  }
+};
 
 export default function Senadores() {
   return (
@@ -31,6 +35,5 @@ export default function Senadores() {
         <SenadoresContent />
       </Suspense>
     </div>
-  )
+  );
 }
-

--- a/app/votaciones/page.tsx
+++ b/app/votaciones/page.tsx
@@ -1,32 +1,39 @@
-import type { Metadata } from "next"
-import VotacionesPageClient from "./VotacionesPageClient"
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import VotacionesPageClient from "./VotacionesPageClient";
 
 export const metadata: Metadata = {
   title: "Votaciones",
-  description: "Consulta todas las votaciones realizadas en el Senado de la Nación Argentina, filtra por fecha, tipo y resultado.",
+  description:
+    "Consulta todas las votaciones realizadas en el Senado de la Nación Argentina, filtra por fecha, tipo y resultado.",
   openGraph: {
     title: "Votaciones | Senado Argentino",
-    description: "Consulta todas las votaciones realizadas en el Senado de la Nación Argentina, filtra por fecha, tipo y resultado.",
-    images: [{
-      url: '/meta-image.png',
-      width: 1200,
-      height: 630,
-      alt: 'Votaciones del Senado Argentino'
-    }]
+    description:
+      "Consulta todas las votaciones realizadas en el Senado de la Nación Argentina, filtra por fecha, tipo y resultado.",
+    images: [
+      {
+        url: "/meta-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Votaciones del Senado Argentino"
+      }
+    ]
   },
   twitter: {
-    card: 'summary_large_image',
+    card: "summary_large_image",
     title: "Votaciones | Senado Argentino",
-    description: "Consulta todas las votaciones realizadas en el Senado de la Nación Argentina, filtra por fecha, tipo y resultado.",
-    images: ['/meta-image.png']
+    description:
+      "Consulta todas las votaciones realizadas en el Senado de la Nación Argentina, filtra por fecha, tipo y resultado.",
+    images: ["/meta-image.png"]
   }
-}
+};
 
 export default function VotacionesPage() {
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900">
-      <VotacionesPageClient />
+      <Suspense fallback={<div>Cargando votaciones...</div>}>
+        <VotacionesPageClient />
+      </Suspense>
     </div>
-  )
+  );
 }
-


### PR DESCRIPTION
- Búsqueda por títulos en `/votaciones` con URL params (ejemplo: /votaciones?search=Libra&year=2025) para compartir resultados más fácilmente y mejorar SEO
- Le agregué `metadataBase: new URL('https://senadores.argentinadatos.com'),` a las props de Metadata en layout.tsx para evitar la advertencia al correr `npm run build`. Mejora para el SEO.